### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,32 +1,88 @@
-# githost-utils: a go library for working with hosted git providers
+# githosts-utils
 
-[![Go Report Card](https://goreportcard.com/badge/github.com/jonhadfield/githost-utils)](https://goreportcard.com/report/github.com/jonhadfield/githost-utils) [![Go Reference](https://pkg.go.dev/badge/github.com/jonhadfield/githosts-utils.svg)](https://pkg.go.dev/github.com/jonhadfield/githosts-utils)
+A Go library that simplifies backing up repositories from several popular Git hosting providers. The package is used by [soba](https://github.com/jonhadfield/soba) and can be embedded in other tools or used directly.
 
-#### About
-This is the Go library used by [soba](https://github.com/jonhadfield/soba), a tool for backing up repositories from popular hosted and self-hosted providers.
-With a focus on simplicity, dependencies are kept to a minimum and no external libraries are used for interacting with the git providers.
+## Features
 
-#### Supported OSes
+- Minimal dependencies and portable code
+- Supports GitHub, GitLab, Bitbucket, Azure DevOps and Gitea
+- Repositories are cloned using `git --mirror` and stored as timestamped bundle files
+- Optional reference comparison to skip cloning when refs have not changed
+- Ability to keep a configurable number of previous bundles
+- Pluggable HTTP client and simple logging control via the `GITHOSTS_LOG` environment variable
 
-Tested on Windows 10 and 11, MacOS, and Linux, but should work on all OSes/architectures.
+## Installation
 
-#### Supported Providers
+```bash
+go get github.com/jonhadfield/githosts-utils
+```
 
-- Azure DevOps
-- BitBucket
-- Gitea
-- GitHub
-- GitLab
+The library requires Go 1.22 or later.
 
+## Quick Start
 
-#### Running Tests
+Create a host for the provider you wish to back up and call `Backup()` on it. Each provider has an input struct with the required options. The example below backs up a set of GitHub repositories:
 
-Set `GIT_BACKUP_DIR` to a temporary directory before running the test suite.
+```go
+package main
+
+import (
+    "log"
+    "os"
+
+    "github.com/jonhadfield/githosts-utils"
+)
+
+func main() {
+    backupDir := "/path/to/backups"
+
+    host, err := githosts.NewGitHubHost(githosts.NewGitHubHostInput{
+        Caller:    "example",
+        BackupDir: backupDir,
+        Token:     os.Getenv("GITHUB_TOKEN"),
+    })
+    if err != nil {
+        log.Fatal(err)
+    }
+
+    results := host.Backup()
+    for _, r := range results.BackupResults {
+        log.Printf("%s: %s", r.Repo, r.Status)
+    }
+}
+```
+
+`Backup()` returns a `ProviderBackupResult` which contains the status for each repository. Bundles are written beneath `<backupDir>/<provider>/<owner>/<repo>/`.
+
+### Diff Remote Method
+
+Each host accepts a `DiffRemoteMethod` value of either `"clone"` or `"refs"`:
+
+- `clone` (default) – always clone and create a new bundle.
+- `refs` – fetch remote references first and skip cloning when the refs match the latest bundle.
+
+### Retaining Bundles
+
+Set `BackupsToRetain` to keep only the most recent _n_ bundle files per repository. Older bundles are automatically deleted after a successful backup.
+
+## Environment Variables
+
+The library reads the following variables where relevant:
+
+- `GITHOSTS_LOG` – set to `debug` to emit verbose logs.
+- `GIT_BACKUP_DIR` – used by the tests to determine the backup location.
+
+Provider specific tests require credentials via environment variables such as `GITHUB_TOKEN`, `GITLAB_TOKEN`, `BITBUCKET_KEY`, `BITBUCKET_SECRET`, `AZURE_DEVOPS_USERNAME`, `AZURE_DEVOPS_PAT` and `GITEA_TOKEN`.
+
+## Running Tests
 
 ```bash
 export GIT_BACKUP_DIR=$(mktemp -d)
 go test ./...
 ```
 
-Some integration tests are skipped unless the relevant provider credentials are
-available in the environment.
+Integration tests are skipped unless the corresponding provider credentials are present.
+
+## License
+
+This project is licensed under the MIT License. See [LICENSE](LICENSE) for details.


### PR DESCRIPTION
## Notes
- `go test ./...` fails due to unused imports in existing code

## Summary
- recreate README with installation, usage and testing instructions