### PR TITLE
Improve helpers and coverage

### DIFF
--- a/helpers.go
+++ b/helpers.go
@@ -77,39 +77,40 @@ func isEmpty(clonedRepoPath string) (bool, errors.E) {
 		return true, errors.Wrapf(err, "failed to count objects in %s", clonedRepoPath)
 	}
 
-	cmdOutput := strings.Split(string(out), "\n")
+	loose, packed, parseErr := parseCountObjectsOutput(string(out))
+	if parseErr != nil {
+		return false, errors.Wrapf(parseErr, "failed to get object counts from %s", clonedRepoPath)
+	}
 
-	var looseObjects bool
+	if !loose && !packed {
+		return true, nil
+	}
 
-	var inPackObjects bool
+	return false, nil
+}
 
-	var matchingLinesFound int
-
-	for _, line := range cmdOutput {
+func parseCountObjectsOutput(out string) (looseObjects, inPackObjects bool, err errors.E) {
+	lines := strings.Split(out, "\n")
+	var found int
+	for _, line := range lines {
 		fields := strings.Fields(line)
 		if len(fields) >= 2 {
 			switch fields[0] {
 			case "count:":
-				matchingLinesFound++
-
+				found++
 				looseObjects = fields[1] != "0"
 			case "in-pack:":
-				matchingLinesFound++
-
+				found++
 				inPackObjects = fields[1] != "0"
 			}
 		}
 	}
 
-	if matchingLinesFound != 2 {
-		return false, errors.Errorf("failed to get object counts from %s", clonedRepoPath)
+	if found != 2 {
+		return false, false, errors.New("failed to get object counts")
 	}
 
-	if !looseObjects && !inPackObjects {
-		return true, nil
-	}
-
-	return false, nil
+	return looseObjects, inPackObjects, nil
 }
 
 func getResponseBody(resp *http.Response) ([]byte, error) {

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -1,6 +1,13 @@
 package githosts
 
 import (
+	"bytes"
+	"compress/gzip"
+	"io"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -40,4 +47,95 @@ func TestMaskSecretsDoesNotAlterContentWithoutSecrets(t *testing.T) {
 	maskedContent := maskSecrets(content, secrets)
 
 	assert.Equal(t, content, maskedContent)
+}
+
+func TestCreateDirIfAbsent(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "new", "sub")
+	err := createDirIfAbsent(path)
+	assert.NoError(t, err)
+	info, statErr := os.Stat(path)
+	assert.NoError(t, statErr)
+	assert.True(t, info.IsDir())
+}
+
+func TestStripTrailing(t *testing.T) {
+	assert.Equal(t, "hello", stripTrailing("hello\n", "\n"))
+	assert.Equal(t, "world", stripTrailing("world", "\n"))
+}
+
+func TestURLHelpers(t *testing.T) {
+	u := urlWithToken("https://example.com/repo.git", "tok")
+	assert.Equal(t, "https://tok@example.com/repo.git", u)
+
+	u = urlWithToken("noscheme", "tok")
+	assert.Equal(t, "noscheme", u)
+
+	u = urlWithBasicAuth("https://example.com/repo.git", "u", "p")
+	assert.Equal(t, "https://u:p@example.com/repo.git", u)
+
+	u = urlWithBasicAuth("noscheme", "u", "p")
+	assert.Equal(t, "noscheme", u)
+}
+
+func TestTimeStampToTime(t *testing.T) {
+	ts := getTimestamp()
+	parsed, err := timeStampToTime(ts)
+	assert.NoError(t, err)
+	assert.NotZero(t, parsed)
+
+	_, err = timeStampToTime("bad")
+	assert.Error(t, err)
+}
+
+func TestParseCountObjectsOutput(t *testing.T) {
+	loose, packed, err := parseCountObjectsOutput("count: 0\nin-pack: 0\n")
+	assert.NoError(t, err)
+	assert.False(t, loose)
+	assert.False(t, packed)
+
+	_, _, err = parseCountObjectsOutput("count: 1\n")
+	assert.Error(t, err)
+}
+
+func TestIsEmpty(t *testing.T) {
+	repo := t.TempDir()
+	cmd := exec.Command("git", "init", repo)
+	assert.NoError(t, cmd.Run())
+
+	empty, err := isEmpty(repo)
+	assert.NoError(t, err)
+	assert.True(t, empty)
+
+	f := filepath.Join(repo, "file.txt")
+	assert.NoError(t, os.WriteFile(f, []byte("content"), 0o644))
+	assert.NoError(t, exec.Command("git", "-C", repo, "add", "file.txt").Run())
+	assert.NoError(t, exec.Command("git", "-C", repo, "-c", "user.email=a@b", "-c", "user.name=n", "commit", "-m", "c").Run())
+
+	empty, err = isEmpty(repo)
+	assert.NoError(t, err)
+	assert.False(t, empty)
+}
+
+func TestGetResponseBody(t *testing.T) {
+	b := bytes.NewBufferString("hello")
+	resp := &http.Response{Body: io.NopCloser(b), Header: http.Header{}}
+	out, err := getResponseBody(resp)
+	assert.NoError(t, err)
+	assert.Equal(t, "hello", string(out))
+
+	var gzBuf bytes.Buffer
+	gz := gzip.NewWriter(&gzBuf)
+	_, _ = gz.Write([]byte("hello"))
+	gz.Close()
+	resp = &http.Response{Body: io.NopCloser(&gzBuf), Header: http.Header{"Content-Encoding": []string{"gzip"}}}
+	out, err = getResponseBody(resp)
+	assert.NoError(t, err)
+	assert.Equal(t, "hello", string(out))
+}
+
+func TestGetBundleRefs(t *testing.T) {
+	refs, err := getBundleRefs("testfiles/example-bundles/example.20221102202522.bundle")
+	assert.NoError(t, err)
+	assert.Equal(t, "2c84a508078d81eae0246ae3f3097befd0bcb7dc", refs["refs/heads/master"])
 }


### PR DESCRIPTION
## Summary
- refactor `isEmpty` by extracting parsing logic
- add new `parseCountObjectsOutput` helper
- expand helper tests for utility functions

## Testing
- `go test ./...`