### PR TITLE
Increase test coverage

### DIFF
--- a/helpers_test.go
+++ b/helpers_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestMaskSecretsReplacesSecretsWithAsterisks(t *testing.T) {
@@ -138,4 +139,10 @@ func TestGetBundleRefs(t *testing.T) {
 	refs, err := getBundleRefs("testfiles/example-bundles/example.20221102202522.bundle")
 	assert.NoError(t, err)
 	assert.Equal(t, "2c84a508078d81eae0246ae3f3097befd0bcb7dc", refs["refs/heads/master"])
+}
+
+func TestRemoveNotFound(t *testing.T) {
+	s := []string{"a", "b", "c"}
+	out := remove(s, "z")
+	require.Equal(t, s, out)
 }

--- a/http_request_test.go
+++ b/http_request_test.go
@@ -1,0 +1,50 @@
+package githosts
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/go-retryablehttp"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHTTPRequestSuccess(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("unexpected method %s", r.Method)
+		}
+		if r.Header.Get("X-Test") != "true" {
+			t.Errorf("missing header")
+		}
+		b, _ := io.ReadAll(r.Body)
+		_, _ = w.Write([]byte("resp:" + string(b)))
+	}))
+	defer srv.Close()
+
+	client := retryablehttp.NewClient()
+	body, hdr, code, err := httpRequest(httpRequestInput{
+		client:  client,
+		url:     srv.URL,
+		method:  http.MethodPost,
+		headers: http.Header{"X-Test": {"true"}},
+		reqBody: []byte("input"),
+		timeout: time.Second,
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, 200, code)
+	require.Equal(t, "resp:input", string(body))
+	require.Equal(t, "text/plain; charset=utf-8", hdr.Get("Content-Type"))
+}
+
+func TestHTTPRequestNoMethod(t *testing.T) {
+	client := retryablehttp.NewClient()
+	_, _, _, err := httpRequest(httpRequestInput{
+		client: client,
+		url:    "http://example.com",
+	})
+	require.Error(t, err)
+}


### PR DESCRIPTION
## Summary
- test httpRequest success and error handling
- ensure remove function behaves when item not found

## Testing
- `go test ./... -coverprofile=coverage.out`


------
https://chatgpt.com/codex/tasks/task_e_684eaae1d76c8320b1b72d6ac4d3dd5b