### PR TITLE
Fix getEnvOrFile logging

### DIFF
--- a/envfile.go
+++ b/envfile.go
@@ -3,30 +3,21 @@
 package githosts
 
 import (
-	"fmt"
 	"os"
 	"strings"
 )
 
 // getEnvOrFile returns the value of the environment variable if set, otherwise if a corresponding _FILE variable is set, reads the value from the file at that path.
 func getEnvOrFile(envVar string) string {
-	ev := os.Environ()
-	for k, v := range ev {
-		fmt.Printf("Environment variable %d: %s=%s\n", k, v, os.Getenv(v))
-	}
-
-	val := os.Getenv(envVar)
-	fmt.Printf("getEnvOrFile: envVar=%s, value=%s\n", envVar, val)
+	val := strings.TrimSpace(os.Getenv(envVar))
 	if val != "" {
 		return val
 	}
 
 	fileEnv := envVar + "_FILE"
-
-	filePath := os.Getenv(fileEnv)
+	filePath := strings.TrimSpace(os.Getenv(fileEnv))
 	if filePath != "" {
-		b, err := os.ReadFile(strings.TrimSpace(filePath))
-		if err == nil {
+		if b, err := os.ReadFile(filePath); err == nil {
 			return strings.TrimSpace(string(b))
 		}
 	}


### PR DESCRIPTION
## Summary
- clean up `getEnvOrFile` function
- remove noisy debug output

## Testing
- `go vet ./...`
- `GIT_BACKUP_DIR=/tmp go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6851f63cd8b083208d0537748e3e033a