### PR TITLE
Improve Git error visibility

### DIFF
--- a/bundles.go
+++ b/bundles.go
@@ -72,7 +72,11 @@ func getBundleRefs(bundlePath string) (gitRefs, error) {
 
 	out, bundleRefsCmdErr := bundleRefsCmd.CombinedOutput()
 	if bundleRefsCmdErr != nil {
-		return nil, errors.New(string(out))
+		gitErr := parseGitError(out)
+		if gitErr != "" {
+			return nil, errors.Errorf("git bundle list-heads failed: %s", gitErr)
+		}
+		return nil, errors.Wrap(bundleRefsCmdErr, "git bundle list-heads failed")
 	}
 
 	refs, err := generateMapFromRefsCmdOutput(out)


### PR DESCRIPTION
## Summary
- parse git stderr for fatal or error lines
- include parsed git errors when listing bundle refs
- include parsed git errors for remote refs
- wrap git clone errors with parsed messages

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68546828f0508320848e5f9c3dbe0d1e