### PR TITLE
Add missing unit tests and enable parallelization

### DIFF
--- a/canonicaldiff_test.go
+++ b/canonicaldiff_test.go
@@ -1,0 +1,23 @@
+package githosts
+
+import "testing"
+
+func TestCanonicalDiffRemoteMethodRefs(t *testing.T) {
+	t.Parallel()
+	if m := canonicalDiffRemoteMethod("refs"); m != refsMethod {
+		t.Fatalf("expected %s got %s", refsMethod, m)
+	}
+	if m := canonicalDiffRemoteMethod("ReFs"); m != refsMethod {
+		t.Fatalf("case insensitive expected %s got %s", refsMethod, m)
+	}
+}
+
+func TestCanonicalDiffRemoteMethodDefault(t *testing.T) {
+	t.Parallel()
+	if m := canonicalDiffRemoteMethod("clone"); m != cloneMethod {
+		t.Fatalf("expected %s got %s", cloneMethod, m)
+	}
+	if m := canonicalDiffRemoteMethod("bad"); m != cloneMethod {
+		t.Fatalf("unexpected %s", m)
+	}
+}

--- a/core_additional_test.go
+++ b/core_additional_test.go
@@ -10,6 +10,7 @@ import (
 )
 
 func TestCutBySpaceAndTrimOutput(t *testing.T) {
+	t.Parallel()
 	cases := []struct {
 		in     string
 		before string
@@ -31,6 +32,7 @@ func TestCutBySpaceAndTrimOutput(t *testing.T) {
 }
 
 func TestGenerateBasicAuth(t *testing.T) {
+	t.Parallel()
 	out := generateBasicAuth("bob", "batteryhorsestaple")
 	expected := base64.StdEncoding.EncodeToString([]byte("bob:batteryhorsestaple"))
 	if out != expected {
@@ -52,6 +54,7 @@ func TestSetLoggerPrefix(t *testing.T) {
 }
 
 func TestValidDiffRemoteMethod(t *testing.T) {
+	t.Parallel()
 	if err := validDiffRemoteMethod("clone"); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -64,6 +67,7 @@ func TestValidDiffRemoteMethod(t *testing.T) {
 }
 
 func TestGetDiffRemoteMethod(t *testing.T) {
+	t.Parallel()
 	m, err := getDiffRemoteMethod("clone")
 	if err != nil || m != "clone" {
 		t.Fatalf("unexpected result: %s %v", m, err)
@@ -78,6 +82,7 @@ func TestGetDiffRemoteMethod(t *testing.T) {
 }
 
 func TestGetHTTPClient(t *testing.T) {
+	t.Parallel()
 	c := getHTTPClient()
 	if c == nil || c.HTTPClient == nil {
 		t.Fatal("nil client")
@@ -91,6 +96,7 @@ func TestGetHTTPClient(t *testing.T) {
 }
 
 func TestToPtr(t *testing.T) {
+	t.Parallel()
 	v := 10
 	p := ToPtr(v)
 	if *p != v {
@@ -99,12 +105,14 @@ func TestToPtr(t *testing.T) {
 }
 
 func TestExtractDomainFromAPIUrl(t *testing.T) {
+	t.Parallel()
 	if d := extractDomainFromAPIUrl("https://gitea.example.com/api/v1"); d != "gitea.example.com" {
 		t.Errorf("unexpected domain %s", d)
 	}
 }
 
 func TestGetRemoteRefs(t *testing.T) {
+	t.Parallel()
 	tmp := t.TempDir()
 	remoteDir := filepath.Join(tmp, "remote")
 	if err := os.MkdirAll(remoteDir, 0o755); err != nil {

--- a/envfile_test.go
+++ b/envfile_test.go
@@ -1,0 +1,32 @@
+package githosts
+
+import (
+	"os"
+	"testing"
+)
+
+func TestGetEnvOrFileReturnsEnvValue(t *testing.T) {
+	t.Setenv("TESTVAR", "value")
+	t.Setenv("TESTVAR_FILE", "/tmp/should-not-read")
+	if v := getEnvOrFile("TESTVAR"); v != "value" {
+		t.Fatalf("expected env value, got %q", v)
+	}
+}
+
+func TestGetEnvOrFileReturnsFileValue(t *testing.T) {
+	file := t.TempDir() + "/f"
+	os.WriteFile(file, []byte("fileval"), 0o644)
+	t.Setenv("TESTVAR", "")
+	t.Setenv("TESTVAR_FILE", file)
+	if v := getEnvOrFile("TESTVAR"); v != "fileval" {
+		t.Fatalf("expected file value, got %q", v)
+	}
+}
+
+func TestGetEnvOrFileEmptyWhenUnset(t *testing.T) {
+	t.Setenv("TESTVAR", "")
+	t.Setenv("TESTVAR_FILE", "")
+	if v := getEnvOrFile("TESTVAR"); v != "" {
+		t.Fatalf("expected empty string, got %q", v)
+	}
+}

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -15,6 +15,7 @@ import (
 )
 
 func TestMaskSecretsReplacesSecretsWithAsterisks(t *testing.T) {
+	t.Parallel()
 	content := "Hello, my secret is secret123"
 	secrets := []string{"secret123"}
 
@@ -24,6 +25,7 @@ func TestMaskSecretsReplacesSecretsWithAsterisks(t *testing.T) {
 }
 
 func TestMaskSecretsHandlesMultipleSecrets(t *testing.T) {
+	t.Parallel()
 	content := "Hello, my secrets are secret123 and secret456"
 	secrets := []string{"secret123", "secret456"}
 
@@ -33,6 +35,7 @@ func TestMaskSecretsHandlesMultipleSecrets(t *testing.T) {
 }
 
 func TestMaskSecretsReturnsOriginalContentWhenNoSecrets(t *testing.T) {
+	t.Parallel()
 	content := "Hello, I have no secrets"
 	secrets := []string{}
 
@@ -42,6 +45,7 @@ func TestMaskSecretsReturnsOriginalContentWhenNoSecrets(t *testing.T) {
 }
 
 func TestMaskSecretsDoesNotAlterContentWithoutSecrets(t *testing.T) {
+	t.Parallel()
 	content := "Hello, my secret is not here"
 	secrets := []string{"secret123"}
 
@@ -51,6 +55,7 @@ func TestMaskSecretsDoesNotAlterContentWithoutSecrets(t *testing.T) {
 }
 
 func TestCreateDirIfAbsent(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	path := filepath.Join(dir, "new", "sub")
 	err := createDirIfAbsent(path)
@@ -61,11 +66,13 @@ func TestCreateDirIfAbsent(t *testing.T) {
 }
 
 func TestStripTrailing(t *testing.T) {
+	t.Parallel()
 	assert.Equal(t, "hello", stripTrailing("hello\n", "\n"))
 	assert.Equal(t, "world", stripTrailing("world", "\n"))
 }
 
 func TestURLHelpers(t *testing.T) {
+	t.Parallel()
 	u := urlWithToken("https://example.com/repo.git", "tok")
 	assert.Equal(t, "https://tok@example.com/repo.git", u)
 
@@ -80,6 +87,7 @@ func TestURLHelpers(t *testing.T) {
 }
 
 func TestTimeStampToTime(t *testing.T) {
+	t.Parallel()
 	ts := getTimestamp()
 	parsed, err := timeStampToTime(ts)
 	assert.NoError(t, err)
@@ -90,6 +98,7 @@ func TestTimeStampToTime(t *testing.T) {
 }
 
 func TestParseCountObjectsOutput(t *testing.T) {
+	t.Parallel()
 	loose, packed, err := parseCountObjectsOutput("count: 0\nin-pack: 0\n")
 	assert.NoError(t, err)
 	assert.False(t, loose)
@@ -100,6 +109,7 @@ func TestParseCountObjectsOutput(t *testing.T) {
 }
 
 func TestIsEmpty(t *testing.T) {
+	t.Parallel()
 	repo := t.TempDir()
 	cmd := exec.Command("git", "init", repo)
 	assert.NoError(t, cmd.Run())
@@ -119,6 +129,7 @@ func TestIsEmpty(t *testing.T) {
 }
 
 func TestGetResponseBody(t *testing.T) {
+	t.Parallel()
 	b := bytes.NewBufferString("hello")
 	resp := &http.Response{Body: io.NopCloser(b), Header: http.Header{}}
 	out, err := getResponseBody(resp)
@@ -136,12 +147,14 @@ func TestGetResponseBody(t *testing.T) {
 }
 
 func TestGetBundleRefs(t *testing.T) {
+	t.Parallel()
 	refs, err := getBundleRefs("testfiles/example-bundles/example.20221102202522.bundle")
 	assert.NoError(t, err)
 	assert.Equal(t, "2c84a508078d81eae0246ae3f3097befd0bcb7dc", refs["refs/heads/master"])
 }
 
 func TestRemoveNotFound(t *testing.T) {
+	t.Parallel()
 	s := []string{"a", "b", "c"}
 	out := remove(s, "z")
 	require.Equal(t, s, out)

--- a/http_request_test.go
+++ b/http_request_test.go
@@ -12,6 +12,7 @@ import (
 )
 
 func TestHTTPRequestSuccess(t *testing.T) {
+	t.Parallel()
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {
 			t.Errorf("unexpected method %s", r.Method)
@@ -41,6 +42,7 @@ func TestHTTPRequestSuccess(t *testing.T) {
 }
 
 func TestHTTPRequestNoMethod(t *testing.T) {
+	t.Parallel()
 	client := retryablehttp.NewClient()
 	body, hdr, code, err := httpRequest(httpRequestInput{
 		client: client,

--- a/parsegiterror_test.go
+++ b/parsegiterror_test.go
@@ -1,0 +1,23 @@
+package githosts
+
+import "testing"
+
+func TestParseGitErrorFiltersLines(t *testing.T) {
+	t.Parallel()
+
+	in := []byte("fatal: bad\nerror: nope\n info")
+	out := parseGitError(in)
+	if out != "fatal: bad, error: nope" {
+		t.Fatalf("unexpected output %q", out)
+	}
+}
+
+func TestParseGitErrorNoPrefixes(t *testing.T) {
+	t.Parallel()
+
+	in := []byte("warning: x\nhello")
+	out := parseGitError(in)
+	if out != "warning: x, hello" {
+		t.Fatalf("unexpected output %q", out)
+	}
+}

--- a/remote_refs_test.go
+++ b/remote_refs_test.go
@@ -8,6 +8,7 @@ import (
 )
 
 func TestRemoteRefsMatchLocalRefsTrue(t *testing.T) {
+	t.Parallel()
 	tmpDir := t.TempDir()
 	remoteDir := filepath.Join(tmpDir, "remote")
 	backupDir := filepath.Join(tmpDir, "backup")
@@ -33,6 +34,7 @@ func TestRemoteRefsMatchLocalRefsTrue(t *testing.T) {
 }
 
 func TestRemoteRefsMatchLocalRefsFalse(t *testing.T) {
+	t.Parallel()
 	tmpDir := t.TempDir()
 	remoteDir := filepath.Join(tmpDir, "remote")
 	backupDir := filepath.Join(tmpDir, "backup")


### PR DESCRIPTION
## Summary
- add tests for env var file fallback logic
- test git error parsing
- cover canonical diff method helper
- enable safe parallel execution in unit tests

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685a539564608320b733b7206e1f5f9f