### PR TITLE
refactor: centralize log message strings

### DIFF
--- a/azuredevops.go
+++ b/azuredevops.go
@@ -20,8 +20,6 @@ import (
 )
 
 const (
-	sUsingDiffRemoteMethod            = "using diff remote method"
-	sUsingDefaultDiffRemoteMethod     = "using default diff remote method"
 	AzureDevOpsProviderName           = "AzureDevOps"
 	azureDevOpsDomain                 = "dev.azure.com"
 	envAzureDevOpsUserName            = "AZURE_DEVOPS_USERNAME"
@@ -30,11 +28,11 @@ const (
 
 func (ad *AzureDevOpsHost) Backup() ProviderBackupResult {
 	if ad.BackupDir == "" {
-		logger.Printf("backup skipped as backup directory not specified")
+		logger.Printf(msgBackupSkippedNoDir)
 
 		return ProviderBackupResult{
 			BackupResults: nil,
-			Error:         errors.New("backup directory not specified"),
+			Error:         errors.New(msgBackupDirNotSpecified),
 		}
 	}
 
@@ -90,7 +88,7 @@ func NewAzureDevOpsHost(input NewAzureDevOpsHostInput) (*AzureDevOpsHost, error)
 
 	switch {
 	case input.BackupDir == "":
-		return nil, errors.New("backup directory not specified")
+		return nil, errors.New(msgBackupDirNotSpecified)
 	case input.UserName == "":
 		return nil, errors.New("username not specified")
 	case input.PAT == "":
@@ -105,10 +103,10 @@ func NewAzureDevOpsHost(input NewAzureDevOpsHostInput) (*AzureDevOpsHost, error)
 	}
 
 	if diffRemoteMethod == "" {
-		logger.Printf("%s: %s", sUsingDefaultDiffRemoteMethod, defaultRemoteMethod)
+		logger.Printf("%s: %s", msgUsingDefaultDiffRemoteMethod, defaultRemoteMethod)
 		diffRemoteMethod = defaultRemoteMethod
 	} else {
-		logger.Printf("%s: %s", sUsingDiffRemoteMethod, diffRemoteMethod)
+		logger.Printf("%s: %s", msgUsingDiffRemoteMethod, diffRemoteMethod)
 	}
 
 	httpClient := input.HTTPClient

--- a/bitbucket.go
+++ b/bitbucket.go
@@ -74,10 +74,10 @@ func NewBitBucketHost(input NewBitBucketHostInput) (*BitbucketHost, error) {
 	}
 
 	if diffRemoteMethod == "" {
-		logger.Print("using default diff remote method: " + defaultRemoteMethod)
+		logger.Print(msgUsingDefaultDiffRemoteMethod + ": " + defaultRemoteMethod)
 		diffRemoteMethod = defaultRemoteMethod
 	} else {
-		logger.Print("using diff remote method: " + diffRemoteMethod)
+		logger.Print(msgUsingDiffRemoteMethod + ": " + diffRemoteMethod)
 	}
 
 	httpClient := input.HTTPClient
@@ -407,7 +407,7 @@ func bitBucketWorker(logLevel int, email, token, apiToken, backupDIR, diffRemote
 
 func (bb BitbucketHost) Backup() ProviderBackupResult {
 	if bb.BackupDir == "" {
-		logger.Printf("backup skipped as backup directory not specified")
+		logger.Printf(msgBackupSkippedNoDir)
 
 		return ProviderBackupResult{}
 	}

--- a/core.go
+++ b/core.go
@@ -16,14 +16,18 @@ import (
 )
 
 const (
-	envVarGitBackupDir  = "GIT_BACKUP_DIR"
-	envVarGitHostsLog   = "GITHOSTS_LOG"
-	refsMethod          = "refs"
-	cloneMethod         = "clone"
-	defaultRemoteMethod = cloneMethod
-	logEntryPrefix      = "githosts-utils: "
-	statusOk            = "ok"
-	statusFailed        = "failed"
+	envVarGitBackupDir              = "GIT_BACKUP_DIR"
+	envVarGitHostsLog               = "GITHOSTS_LOG"
+	refsMethod                      = "refs"
+	cloneMethod                     = "clone"
+	defaultRemoteMethod             = cloneMethod
+	logEntryPrefix                  = "githosts-utils: "
+	statusOk                        = "ok"
+	statusFailed                    = "failed"
+	msgUsingDiffRemoteMethod        = "using diff remote method"
+	msgUsingDefaultDiffRemoteMethod = "using default diff remote method"
+	msgBackupSkippedNoDir           = "backup skipped as backup directory not specified"
+	msgBackupDirNotSpecified        = "backup directory not specified"
 )
 
 type repository struct {

--- a/gitea.go
+++ b/gitea.go
@@ -72,10 +72,10 @@ func NewGiteaHost(input NewGiteaHostInput) (*GiteaHost, error) {
 	}
 
 	if diffRemoteMethod == "" {
-		logger.Print("using default diff remote method: " + defaultRemoteMethod)
+		logger.Print(msgUsingDefaultDiffRemoteMethod + ": " + defaultRemoteMethod)
 		diffRemoteMethod = defaultRemoteMethod
 	} else {
-		logger.Print("using diff remote method: " + diffRemoteMethod)
+		logger.Print(msgUsingDiffRemoteMethod + ": " + diffRemoteMethod)
 	}
 
 	httpClient := input.HTTPClient
@@ -970,7 +970,7 @@ func giteaWorker(token string, logLevel int, backupDIR, diffRemoteMethod string,
 
 func (g *GiteaHost) Backup() ProviderBackupResult {
 	if g.BackupDir == "" {
-		logger.Printf("backup skipped as backup directory not specified")
+		logger.Printf(msgBackupSkippedNoDir)
 
 		return ProviderBackupResult{}
 	}

--- a/github.go
+++ b/github.go
@@ -58,10 +58,10 @@ func NewGitHubHost(input NewGitHubHostInput) (*GitHubHost, error) {
 	}
 
 	if diffRemoteMethod == "" {
-		logger.Print("using default diff remote method: " + defaultRemoteMethod)
+		logger.Print(msgUsingDefaultDiffRemoteMethod + ": " + defaultRemoteMethod)
 		diffRemoteMethod = defaultRemoteMethod
 	} else {
-		logger.Print("using diff remote method: " + diffRemoteMethod)
+		logger.Print(msgUsingDiffRemoteMethod + ": " + diffRemoteMethod)
 	}
 
 	httpClient := input.HTTPClient
@@ -500,11 +500,11 @@ func gitHubWorker(logLevel int, token, backupDIR, diffRemoteMethod string, backu
 
 func (gh *GitHubHost) Backup() ProviderBackupResult {
 	if gh.BackupDir == "" {
-		logger.Printf("backup skipped as backup directory not specified")
+		logger.Printf(msgBackupSkippedNoDir)
 
 		return ProviderBackupResult{
 			BackupResults: nil,
-			Error:         errors.New("backup directory not specified"),
+			Error:         errors.New(msgBackupDirNotSpecified),
 		}
 	}
 

--- a/gitlab.go
+++ b/gitlab.go
@@ -323,10 +323,10 @@ func NewGitLabHost(input NewGitLabHostInput) (*GitLabHost, error) {
 	}
 
 	if diffRemoteMethod == "" {
-		logger.Print("using default diff remote method: " + defaultRemoteMethod)
+		logger.Print(msgUsingDefaultDiffRemoteMethod + ": " + defaultRemoteMethod)
 		diffRemoteMethod = defaultRemoteMethod
 	} else {
-		logger.Print("using diff remote method: " + diffRemoteMethod)
+		logger.Print(msgUsingDiffRemoteMethod + ": " + diffRemoteMethod)
 	}
 
 	httpClient := input.HTTPClient
@@ -383,7 +383,7 @@ func gitlabWorker(logLevel int, userName, token, backupDIR, diffRemoteMethod str
 
 func (gl *GitLabHost) Backup() ProviderBackupResult {
 	if gl.BackupDir == "" {
-		logger.Printf("backup skipped as backup directory not specified")
+		logger.Printf(msgBackupSkippedNoDir)
 
 		return ProviderBackupResult{}
 	}


### PR DESCRIPTION
## Summary
- centralize repeating log messages with constants
- replace hard-coded strings in provider implementations

## Testing
- `go test ./...` *(fails: backup dir not set)*

------
https://chatgpt.com/codex/tasks/task_e_6862315e6c048320a65ed341e11f6a2a