### PR TITLE
github: make GraphQL request timeout configurable, default 120s

### DIFF
--- a/github.go
+++ b/github.go
@@ -17,12 +17,19 @@ import (
 )
 
 const (
-	gitHubCallSize           = 100
-	githubEnvVarCallSize     = "GITHUB_CALL_SIZE"
-	githubEnvVarWorkerDelay  = "GITHUB_WORKER_DELAY"
-	gitHubDomain             = "github.com"
-	gitHubProviderName       = "GitHub"
-	githubDefaultWorkerDelay = 500
+	gitHubCallSize             = 100
+	githubEnvVarCallSize       = "GITHUB_CALL_SIZE"
+	githubEnvVarWorkerDelay    = "GITHUB_WORKER_DELAY"
+	githubEnvVarRequestTimeout = "GITHUB_REQUEST_TIMEOUT"
+	gitHubDomain               = "github.com"
+	gitHubProviderName         = "GitHub"
+	githubDefaultWorkerDelay   = 500
+	// defaultGitHubRequestTimeout bounds a single GraphQL request. It is
+	// larger than the generic per-request timeout so that retryablehttp's
+	// backoff (which honours GitHub secondary-rate-limit Retry-After values,
+	// commonly 60s) can complete within the request context rather than being
+	// cut short by the deadline. Override with GITHUB_REQUEST_TIMEOUT (seconds).
+	defaultGitHubRequestTimeout = 120 * time.Second
 )
 
 type NewGitHubHostInput struct {
@@ -178,10 +185,24 @@ type graphQLRequest struct {
 	Variables string `json:"variables"`
 }
 
+// githubRequestTimeout returns the per-request timeout for GitHub GraphQL
+// calls, honouring the GITHUB_REQUEST_TIMEOUT env var (in seconds) and
+// falling back to defaultGitHubRequestTimeout. Non-positive or unparsable
+// values are ignored so a misconfiguration cannot disable the timeout.
+func githubRequestTimeout() time.Duration {
+	if v := os.Getenv(githubEnvVarRequestTimeout); v != "" {
+		if secs, err := strconv.Atoi(v); err == nil && secs > 0 {
+			return time.Duration(secs) * time.Second
+		}
+	}
+
+	return defaultGitHubRequestTimeout
+}
+
 func (gh *GitHubHost) makeGithubRequest(payload string) (string, errors.E) {
 	contentReader := bytes.NewReader([]byte(payload))
 
-	ctx, cancel := context.WithTimeout(context.Background(), defaultHttpRequestTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), githubRequestTimeout())
 	defer cancel()
 
 	req, newReqErr := retryablehttp.NewRequestWithContext(ctx, http.MethodPost, gh.APIURL, contentReader)

--- a/github_timeout_test.go
+++ b/github_timeout_test.go
@@ -1,0 +1,37 @@
+package githosts
+
+import (
+	"testing"
+	"time"
+)
+
+func TestGithubRequestTimeout(t *testing.T) {
+	tests := []struct {
+		name string
+		set  bool
+		val  string
+		want time.Duration
+	}{
+		{name: "unset uses default", set: false, want: defaultGitHubRequestTimeout},
+		{name: "valid override in seconds", set: true, val: "60", want: 60 * time.Second},
+		{name: "empty falls back to default", set: true, val: "", want: defaultGitHubRequestTimeout},
+		{name: "zero is ignored", set: true, val: "0", want: defaultGitHubRequestTimeout},
+		{name: "negative is ignored", set: true, val: "-5", want: defaultGitHubRequestTimeout},
+		{name: "non-numeric is ignored", set: true, val: "abc", want: defaultGitHubRequestTimeout},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.set {
+				t.Setenv(githubEnvVarRequestTimeout, tc.val)
+			} else {
+				// t.Setenv requires a value; ensure the var is cleared instead.
+				t.Setenv(githubEnvVarRequestTimeout, "")
+			}
+
+			if got := githubRequestTimeout(); got != tc.want {
+				t.Fatalf("githubRequestTimeout() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

The GitHub GraphQL request in `makeGithubRequest` was wrapped in a hardcoded **30s** context (`defaultHttpRequestTimeout`). When GitHub applies **secondary rate limiting** — a `403`/`429` with a `Retry-After` header commonly ≥60s — `retryablehttp`'s backoff (the client is configured to retry for up to `backupTimeout` = 120s and honours `Retry-After`) cannot complete within the 30s context, so the call fails with `context deadline exceeded`.

This surfaces deterministically in downstream test suites (e.g. soba): the first few GitHub API calls succeed, then the cumulative request burst trips the secondary limit and a later "listing GitHub user's owned repositories" call dies at exactly 30s.

## Change

- Add a GitHub-specific default request timeout of **120s** (matching the client's retry budget) instead of the shared 30s.
- Allow overriding it via the `GITHUB_REQUEST_TIMEOUT` env var (seconds), consistent with the existing `GITHUB_CALL_SIZE` / `GITHUB_WORKER_DELAY` knobs.
- Non-positive or unparsable values are ignored so a misconfiguration cannot disable the timeout.

## Test plan

- `go build ./...`, `go vet ./...` — clean
- New `TestGithubRequestTimeout` unit test covers default, valid override, and the empty/zero/negative/non-numeric fallback cases
- `golangci-lint` — no new findings in changed files