### PR TITLE
fix: build GitHub GraphQL request bodies as valid JSON

### DIFF
--- a/github.go
+++ b/github.go
@@ -258,6 +258,23 @@ func (gh *GitHubHost) makeGithubRequest(payload string) (string, errors.E) {
 	return bodyStr, nil
 }
 
+// userReposQuery builds the GraphQL query for the authenticated user's owned
+// repositories. A non-empty after requests the page following that cursor, and
+// owner affiliations are applied when LimitUserOwned is set. The raw query is
+// wrapped into a JSON request body by createGithubRequestPayload.
+func (gh *GitHubHost) userReposQuery(first int, after string) string {
+	args := "first:" + strconv.Itoa(first)
+	if after != "" {
+		args += " after:\"" + after + "\""
+	}
+
+	if gh.LimitUserOwned {
+		args += " affiliations: OWNER ownerAffiliations: OWNER"
+	}
+
+	return "query { viewer { repositories(" + args + ") { edges { node { name nameWithOwner url sshUrl } cursor } pageInfo { endCursor hasNextPage } } } }"
+}
+
 // describeGithubUserRepos returns a list of repositories owned by authenticated user.
 func (gh *GitHubHost) describeGithubUserRepos() ([]repository, errors.E) {
 	logger.Println("listing GitHub user's owned repositories")
@@ -273,16 +290,15 @@ func (gh *GitHubHost) describeGithubUserRepos() ([]repository, errors.E) {
 
 	var repos []repository
 
-	var reqBody string
-
-	if gh.LimitUserOwned {
-		reqBody = "{\"query\": \"query { viewer { repositories(first:" + strconv.Itoa(gcs) + ", affiliations: OWNER, ownerAffiliations: OWNER) { edges { node { name nameWithOwner url sshUrl } cursor } pageInfo { endCursor hasNextPage }} } }\""
-	} else {
-		reqBody = "{\"query\": \"query { viewer { repositories(first:" + strconv.Itoa(gcs) + ") { edges { node { name nameWithOwner url sshUrl } cursor } pageInfo { endCursor hasNextPage }} } }\""
-	}
+	endCursor := ""
 
 	for {
-		bodyStr, err := gh.makeGithubRequest(reqBody)
+		payload, pErr := createGithubRequestPayload(gh.userReposQuery(gcs, endCursor))
+		if pErr != nil {
+			return nil, errors.Wrap(pErr, "failed to create request payload")
+		}
+
+		bodyStr, err := gh.makeGithubRequest(payload)
 		if err != nil {
 			return nil, errors.Wrap(err, "GitHub request failed")
 		}
@@ -306,13 +322,9 @@ func (gh *GitHubHost) describeGithubUserRepos() ([]repository, errors.E) {
 
 		if !respObj.Data.Viewer.Repositories.PageInfo.HasNextPage {
 			break
-		} else {
-			if gh.LimitUserOwned {
-				reqBody = "{\"query\": \"query($first:Int $after:String){ viewer { repositories(first:$first after:$after, affiliations: OWNER, ownerAffiliations: OWNER) { edges { node { name nameWithOwner url sshUrl } cursor } pageInfo { endCursor hasNextPage }} } }\", \"variables\":{\"first\":" + strconv.Itoa(gcs) + ",\"after\":\"" + respObj.Data.Viewer.Repositories.PageInfo.EndCursor + "\"} }"
-			} else {
-				reqBody = "{\"query\": \"query($first:Int $after:String){ viewer { repositories(first:$first after:$after) { edges { node { name nameWithOwner url sshUrl } cursor } pageInfo { endCursor hasNextPage }} } }\", \"variables\":{\"first\":" + strconv.Itoa(gcs) + ",\"after\":\"" + respObj.Data.Viewer.Repositories.PageInfo.EndCursor + "\"} }"
-			}
 		}
+
+		endCursor = respObj.Data.Viewer.Repositories.PageInfo.EndCursor
 	}
 
 	return repos, nil
@@ -323,9 +335,12 @@ func (gh *GitHubHost) describeGithubUserOrganizations() ([]githubOrganization, e
 
 	var orgs []githubOrganization
 
-	reqBody := "{\"query\": \"{ viewer { organizations(first:100) { edges { node { name } } } } }\""
+	payload, pErr := createGithubRequestPayload("{ viewer { organizations(first:100) { edges { node { name } } } } }")
+	if pErr != nil {
+		return nil, errors.Wrap(pErr, "failed to create request payload")
+	}
 
-	bodyStr, err := gh.makeGithubRequest(reqBody)
+	bodyStr, err := gh.makeGithubRequest(payload)
 	if err != nil {
 		logger.Print(err)
 


### PR DESCRIPTION
## Problem

Listing a GitHub account's repositories intermittently **hangs for 60–240s** instead of completing in seconds:

```
github.go: listing GitHub user's owned repositories   <-- stalls here
```

## Root cause

`describeGithubUserRepos` and `describeGithubUserOrganizations` assembled their GraphQL request bodies by hand-concatenating JSON and **omitted the closing brace**, producing an invalid body:

```
{"query": "query { viewer { repositories(first:100) { ... } } }"      <-- no closing }
```

GitHub accepts the malformed body most of the time but **intermittently returns HTTP 502**. A 502 is retryable, and the shared `retryablehttp` client's `RetryWaitMin` is 60s — so each 502 backs off for 60s before retrying (up to ~180s across retries, within the request context). That is the "hang".

Reproduced against a live account: the malformed body returned 502 on ~half of calls; the corrected body returned 200 on 6/6 with zero retries.

## Age of the bug

This is **not a recent regression** — the unclosed body has existed since the initial commit (`8b104d0`, 2018). The recent request-timeout changes (#20/#21) only changed the symptom: the per-request context went 30s → 120s → 240s, so a stall that previously failed fast at 30s now hangs for minutes, which is what made the latent bug visible.

## Fix

Stop hand-building JSON. Construct the raw GraphQL query (via a new `userReposQuery` helper for the paginated viewer query) and wrap it with `createGithubRequestPayload`, which `json.Marshal`-escapes it correctly. This matches the existing org-repos path and removes the malformed-body class of bug, plus the fragile manual cursor escaping.

## Verification

- No hand-built `"query"` JSON remains; build + `go vet` clean; full unit suite passes.
- Live account: 276 repos across 3 paginated pages return in ~4s, 5/5 runs, no 502 retries (was reliably >20s before).