### PR TITLE
build: adopt /v2 module path for semantic import versioning

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/jonhadfield/githosts-utils
+module github.com/jonhadfield/githosts-utils/v2
 
 go 1.25.1
 


### PR DESCRIPTION
## Problem

The repo is tagged `v2.x` but `go.mod` declares the v1-style path `github.com/jonhadfield/githosts-utils`. Per Go's semantic import versioning, a v2+ module's path must end in `/v2`, so:

- `go get github.com/jonhadfield/githosts-utils@v2.1.0` fails: *"module path must match major version"*.
- `go list -m -versions` ignores every `v2.x` tag.
- Consumers (e.g. soba) can only pin pseudo-versions (`v0.0.0-…-<commit>`).

## Fix

Add the `/v2` suffix to the module path. This is a single root package with no internal self-imports, so only the `go.mod` module line changes.

## Impact

**Breaking for importers** — they must change their import to `github.com/jonhadfield/githosts-utils/v2`. Once merged and a `v2.x` tag is cut on top of this, `go get .../v2@vX` will work. (soba's import will be updated in a follow-up.)